### PR TITLE
fix woff2_test failing on #349

### DIFF
--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -226,7 +226,14 @@ class WOFF2Writer(SFNTWriter):
 		"""
 		if self.sfntVersion == "OTTO":
 			return
-		for tag in ('maxp', 'head', 'loca', 'glyf'):
+
+		# make up glyph names required to decompile glyf table
+		self._decompileTable('maxp')
+		numGlyphs = self.ttFont['maxp'].numGlyphs
+		glyphOrder = ['.notdef'] + ["glyph%.5d" % i for i in range(1, numGlyphs)]
+		self.ttFont.setGlyphOrder(glyphOrder)
+
+		for tag in ('head', 'loca', 'glyf'):
 			self._decompileTable(tag)
 		self.ttFont['glyf'].padding = padding
 		for tag in ('glyf', 'loca'):

--- a/Lib/fontTools/ttLib/woff2_test.py
+++ b/Lib/fontTools/ttLib/woff2_test.py
@@ -611,9 +611,11 @@ class WOFF2GlyfTableTest(unittest.TestCase):
 		reader = WOFF2Reader(infile)
 		cls.transformedGlyfData = reader.tables['glyf'].loadData(
 			reader.transformBuffer)
+		cls.glyphOrder = ['.notdef'] + ["glyph%.5d" % i for i in range(1, font['maxp'].numGlyphs)]
 
 	def setUp(self):
 		self.font = font = ttLib.TTFont(recalcBBoxes=False, recalcTimestamp=False)
+		font.setGlyphOrder(self.glyphOrder)
 		font['head'] = ttLib.getTableClass('head')()
 		font['maxp'] = ttLib.getTableClass('maxp')()
 		font['loca'] = WOFF2LocaTable()


### PR DESCRIPTION
the woff2_test is failing with your pull request https://github.com/behdad/fonttools/pull/349 which adds support for non-BMP synthetic glyph names.

https://travis-ci.org/behdad/fonttools/jobs/78730875#L2610

To work around this, I no longer rely on _getGlyphNamesFromCmap to create a glyphOrder when transforming the WOFF2 glyf table. I don't care about the real glyph names here, so I don't want to also decompile cmap or post just to get them.