### PR TITLE
[otTables] skip if element is not tuple when parsing MultipleSubst XML

### DIFF
--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -245,17 +245,23 @@ class MultipleSubst(FormatSwitchingBaseTable):
 
 		# TTX v3.0 and earlier.
 		if name == "Coverage":
-			self.old_coverage_ = [
-				element_attrs["value"]
-				for element_name, element_attrs, _ in content
-				if element_name == "Glyph"]
+			self.old_coverage_ = []
+			for element in content:
+				if not isinstance(element, tuple):
+					continue
+				element_name, element_attrs, _ = element
+				if element_name == "Glyph":
+					self.old_coverage_.append(element_attrs["value"])
 			return
 		if name == "Sequence":
 			glyph = self.old_coverage_[int(attrs["index"])]
-			mapping[glyph] = [
-				element_attrs["value"]
-				for element_name, element_attrs, _ in content
-				if element_name == "Substitute"]
+			glyph_mapping = mapping[glyph] = []
+			for element in content:
+				if not isinstance(element, tuple):
+					continue
+				element_name, element_attrs, _ = element
+				if element_name == "Substitute":
+					glyph_mapping.append(element_attrs["value"])
 			return
 
                 # TTX v3.1 and later.


### PR DESCRIPTION
the content of XML elements can be strings as well as (name, attrs, content)
tuples, so we can't use list comprehension here.

Fixes issue reported in https://github.com/behdad/fonttools/pull/367#issuecomment-139509224